### PR TITLE
[sc-4559] - release action bugfix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: ~> 1.9
-          args: release --rm-dist .
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
go releaser command was: `release --rm-dist .` the `.` is redundant and caused failure on build, this pr removes it.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
