### PR TITLE
fix isse #24 - Show errors on pgm startup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,8 +28,17 @@ var RootCmd = &cobra.Command{
 }
 
 func Execute() error {
-	return RootCmd.Execute()
+        err :=  RootCmd.Execute() // fix isse #24 - Show errors on pgm startup
+        if err != nil {
+                // There was an error! Print the error message and exit. Or do whatever you'd like!
+                // This includes errors like "invalid argument" etc.
+                fmt.Println(err)
+                // os.Exit(1)
+                // the function returns the error in this case
+        }
+        return err
 }
+
 
 func run(cmd *cobra.Command, args []string) error {
 	table := ui.CreateNewTable()


### PR DESCRIPTION
**What this PR does / why we need it**:

 It shows the error when `murre` command throws an exception.

**Which issue(s) this PR fixes**:

Fix isse #24 

**Special notes for your reviewer**:
