### PR TITLE
add --node flag for filtering on pods from specific node

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,12 @@ func initMurreFlags() {
 		"filter by namespace",
 	)
 	RootCmd.Flags().StringVar(
+		&murreConfig.Filters.Node,
+		"node",
+		"",
+		"filter by node",
+	)
+	RootCmd.Flags().StringVar(
 		&murreConfig.Filters.Pod,
 		"pod",
 		"",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,8 @@ var (
 type Filter struct {
 	// filter by namespace
 	Namespace string
+	// filter by node
+	Node string
 	// filter by pod
 	Pod string
 	// filter by container

--- a/pkg/k8s/container.go
+++ b/pkg/k8s/container.go
@@ -8,6 +8,7 @@ type Container struct {
 	Id                         string
 	Name                       string
 	Image                      string
+	NodeName                   string
 	PodName                    string
 	Namespace                  string
 	cpuUsage                   float64
@@ -22,6 +23,7 @@ type Container struct {
 
 type Stats struct {
 	Namespace          string
+	NodeName           string
 	PodName            string
 	ContainerName      string
 	CpuUsageMilli      float64
@@ -59,6 +61,7 @@ func (c *Container) GetStats() *Stats {
 
 	return &Stats{
 		Namespace:          c.Namespace,
+		NodeName:           c.NodeName,
 		PodName:            c.PodName,
 		ContainerName:      c.Name,
 		CpuUsageMilli:      cpuUsageInMillis,

--- a/pkg/k8s/fetcher.go
+++ b/pkg/k8s/fetcher.go
@@ -23,6 +23,7 @@ type ContainerResources struct {
 	PodName   string
 	Name      string
 	Namespace string
+	NodeName  string
 	Image     string
 	Request   Resources
 	Limit     Resources
@@ -81,6 +82,7 @@ func (f *Fetcher) GetContainers() ([]*ContainerResources, error) {
 				PodName:   pod.Name,
 				Name:      container.Name,
 				Namespace: pod.Namespace,
+				NodeName:  pod.Spec.NodeName,
 				Image:     container.Image,
 				Request: Resources{
 					Cpu:    0,


### PR DESCRIPTION
**What this PR does / why we need it**:
While investigating a node with high CPU usage I figured I see what murre would show me. But knowing which node that had high CPU it wasn't super obvious which pods with high CPU usage were actually on that node. So I added a `--node` flag to murre allowing you to filter on a specific node, as well as you could already filter on namespace and pods.

While filtering on a node, murre still fetches metrics from all other nodes, but this is how murre was designed to operate. When you filter on a pod, all data for all other pods is collected as well, but not shown.

